### PR TITLE
Security - Principal object fix

### DIFF
--- a/src/main/java/pl/simpleascoding/tutoringplatform/api/publicResource/TestApi.java
+++ b/src/main/java/pl/simpleascoding/tutoringplatform/api/publicResource/TestApi.java
@@ -1,7 +1,9 @@
 package pl.simpleascoding.tutoringplatform.api.publicResource;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import pl.simpleascoding.tutoringplatform.domain.user.User;
 
 @RestController
 class TestApi {
@@ -12,7 +14,7 @@ class TestApi {
     }
 
     @GetMapping("/testUser")
-    public String testUser() {
-        return "If you can see this, you are a USER";
+    public String testUser(@AuthenticationPrincipal User user) {
+        return String.format("Hi %s %s, you are a USER", user.getName(), user.getSurname());
     }
 }

--- a/src/main/java/pl/simpleascoding/tutoringplatform/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/pl/simpleascoding/tutoringplatform/filter/JwtAuthenticationFilter.java
@@ -47,7 +47,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             UserDetails userDetails = userDetailsService.loadUserByUsername(jwt.getSubject());
 
             SecurityContextHolder.getContext()
-                    .setAuthentication(new UsernamePasswordAuthenticationToken(jwt.getSubject(), null, userDetails.getAuthorities()));
+                    .setAuthentication(new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities()));
             filterChain.doFilter(request, response);
         } catch (RuntimeException ex) {
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);


### PR DESCRIPTION
- Fixed the Principal object: before it was just a String containing a username, now it's the full User object.
This will allow us not to query the database twice in order to get the User object in service methods.

- Modified the testUser endpoint to account for the change above