### PR TITLE
Reverted the @AuthenticationPrincipal change

### DIFF
--- a/src/main/java/pl/simpleascoding/tutoringplatform/api/publicResource/TestApi.java
+++ b/src/main/java/pl/simpleascoding/tutoringplatform/api/publicResource/TestApi.java
@@ -1,9 +1,9 @@
 package pl.simpleascoding.tutoringplatform.api.publicResource;
 
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
-import pl.simpleascoding.tutoringplatform.domain.user.User;
+
+import java.security.Principal;
 
 @RestController
 class TestApi {
@@ -14,7 +14,7 @@ class TestApi {
     }
 
     @GetMapping("/testUser")
-    public String testUser(@AuthenticationPrincipal User user) {
-        return String.format("Hi %s %s, you are a USER", user.getName(), user.getSurname());
+    public String testUser(Principal principal) {
+        return String.format("Hello %s", principal.getName());
     }
 }

--- a/src/main/java/pl/simpleascoding/tutoringplatform/api/publicResource/UserController.java
+++ b/src/main/java/pl/simpleascoding/tutoringplatform/api/publicResource/UserController.java
@@ -3,15 +3,12 @@ package pl.simpleascoding.tutoringplatform.api.publicResource;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import pl.simpleascoding.tutoringplatform.domain.user.User;
 import pl.simpleascoding.tutoringplatform.dto.ChangeUserPasswordDTO;
 import pl.simpleascoding.tutoringplatform.dto.CreateUserDTO;
 import pl.simpleascoding.tutoringplatform.service.user.UserFacade;
 
 import javax.servlet.http.HttpServletRequest;
-
 import java.security.Principal;
 
 @RestController
@@ -32,9 +29,9 @@ class UserController {
     }
 
     @PostMapping("/change-password")
-    ResponseEntity<String> changeUserPassword(@RequestBody ChangeUserPasswordDTO dto, @AuthenticationPrincipal User loggedInUser) {
+    ResponseEntity<String> changeUserPassword(@RequestBody ChangeUserPasswordDTO dto, Principal principal) {
 
-        return new ResponseEntity<>(userFacade.changeUserPassword(dto, loggedInUser), HttpStatus.OK);
+        return new ResponseEntity<>(userFacade.changeUserPassword(dto, principal.getName()), HttpStatus.OK);
 
     }
 

--- a/src/main/java/pl/simpleascoding/tutoringplatform/config/WebSecurityConfig.java
+++ b/src/main/java/pl/simpleascoding/tutoringplatform/config/WebSecurityConfig.java
@@ -33,7 +33,7 @@ class WebSecurityConfig {
 
         httpSecurity.authorizeRequests().antMatchers("/testAdmin").hasAnyAuthority(RoleType.ADMIN.toString());
         httpSecurity.authorizeRequests().antMatchers("/testUser").hasAnyAuthority(RoleType.USER.toString());
-        httpSecurity.authorizeRequests().antMatchers("/change-password").hasAnyAuthority(RoleType.USER.toString());
+        httpSecurity.authorizeRequests().antMatchers("/api/v1/users/change-password").hasAnyAuthority(RoleType.USER.toString());
         httpSecurity.authorizeRequests().anyRequest().permitAll();
         return httpSecurity.build();
     }

--- a/src/main/java/pl/simpleascoding/tutoringplatform/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/pl/simpleascoding/tutoringplatform/filter/JwtAuthenticationFilter.java
@@ -47,7 +47,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             UserDetails userDetails = userDetailsService.loadUserByUsername(jwt.getSubject());
 
             SecurityContextHolder.getContext()
-                    .setAuthentication(new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities()));
+                    .setAuthentication(new UsernamePasswordAuthenticationToken(jwt.getSubject(), null, userDetails.getAuthorities()));
             filterChain.doFilter(request, response);
         } catch (RuntimeException ex) {
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);

--- a/src/main/java/pl/simpleascoding/tutoringplatform/service/user/UserFacade.java
+++ b/src/main/java/pl/simpleascoding/tutoringplatform/service/user/UserFacade.java
@@ -2,7 +2,6 @@ package pl.simpleascoding.tutoringplatform.service.user;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import pl.simpleascoding.tutoringplatform.domain.user.User;
 import pl.simpleascoding.tutoringplatform.dto.ChangeUserPasswordDTO;
 import pl.simpleascoding.tutoringplatform.dto.CreateUserDTO;
 
@@ -24,9 +23,9 @@ public class UserFacade {
 
     }
 
-    public String changeUserPassword(ChangeUserPasswordDTO dto, User user) {
+    public String changeUserPassword(ChangeUserPasswordDTO dto, String username) {
 
-        return userService.changeUserPassword(dto, user);
+        return userService.changeUserPassword(dto, username);
 
     }
 

--- a/src/main/java/pl/simpleascoding/tutoringplatform/service/user/UserService.java
+++ b/src/main/java/pl/simpleascoding/tutoringplatform/service/user/UserService.java
@@ -1,7 +1,6 @@
 package pl.simpleascoding.tutoringplatform.service.user;
 
 import org.springframework.stereotype.Service;
-import pl.simpleascoding.tutoringplatform.domain.user.User;
 import pl.simpleascoding.tutoringplatform.dto.ChangeUserPasswordDTO;
 import pl.simpleascoding.tutoringplatform.dto.CreateUserDTO;
 
@@ -12,6 +11,6 @@ interface UserService {
 
     String confirmUserRegistration(String token);
 
-    String changeUserPassword(ChangeUserPasswordDTO dto, User user);
+    String changeUserPassword(ChangeUserPasswordDTO dto, String username);
 
 }

--- a/src/main/java/pl/simpleascoding/tutoringplatform/service/user/UserServiceImpl.java
+++ b/src/main/java/pl/simpleascoding/tutoringplatform/service/user/UserServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -90,13 +91,16 @@ class UserServiceImpl implements UserService {
      * The password is first checked for correctness of the entered data by the user.
      * Then the currently specified password is checked against the one in storage.
      *
-     * @param newPasswordsData  User-provided multiple password data
-     * @param userEntity    Users entity
-     * @return  The status of the operation
+     * @param newPasswordsData User-provided multiple password data
+     * @param username         Username of the user
+     * @return The status of the operation
      */
     @Override
     @Transactional
-    public String changeUserPassword(ChangeUserPasswordDTO newPasswordsData, User userEntity) {
+    public String changeUserPassword(ChangeUserPasswordDTO newPasswordsData, String username) {
+        User userEntity = userRepository.findUserByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException(username));
+
         if (isChangeAllowed(userEntity.getPassword(), newPasswordsData)) {
             userEntity.setPassword(passwordEncoder.encode(newPasswordsData.newPassword()));
 


### PR DESCRIPTION
- Modified JwtAuthenticationFilter to add only the username of the user to the principal object

- Modified the testUser endpoint to reflect the change above

- Modified the changeUserPassword method to reflect the change above

- Fixed an antMatcher for changeUserPassword in WebSecurityConfig

[Please refer to the Trello task for more details](https://trello.com/c/DmmsE4fZ/31-fix-the-principal-object)