### PR TITLE
Added `orphanRemoval = true` property to the User side of User-Review relation

### DIFF
--- a/src/main/java/pl/simpleascoding/tutoringplatform/domain/user/User.java
+++ b/src/main/java/pl/simpleascoding/tutoringplatform/domain/user/User.java
@@ -39,11 +39,11 @@ public class User implements UserDetails {
     @JoinColumn(name = "user_id")
     private List<Token> tokens = new ArrayList<>();
 
-    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE})
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE}, orphanRemoval = true)
     @JoinColumn(name = "receiver_id")
     private List<Review> receivedReviews = new ArrayList<>();
 
-    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE})
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE}, orphanRemoval = true)
     @JoinColumn(name = "author_id")
     private List<Review> postedReviews = new ArrayList<>();
 


### PR DESCRIPTION
As said on Discord, we need to make sure that our JPA relations are configured properly.
`orphanRemoval = true` allows for child entities to be removed automatically when the relation between them and their parent entity is deleted.
Example: We have created a review for a user, by adding it to the user's `receivedReviews` colletion. But some time after that, we have decided to delete this review, by executing `user.getReceivedReviews().remove(ourReview);`. This code would remove the relation between these objects, but it would not delete the review object from the database.
But if we added the `orphanRemoval = true` property to the relation annotation, the code above would not only delete the relation, but the review object as well.