### PR TITLE
Remove Immutable annotations from DTO records

### DIFF
--- a/src/main/java/pl/simpleascoding/tutoringplatform/dto/ChangeUserPasswordDTO.java
+++ b/src/main/java/pl/simpleascoding/tutoringplatform/dto/ChangeUserPasswordDTO.java
@@ -1,14 +1,12 @@
 package pl.simpleascoding.tutoringplatform.dto;
 
-import org.hibernate.annotations.Immutable;
-
 /**
  * Record used to transfer data (passwords) between the service and the controller
  *
- * @param oldPassword   The user's existing password
- * @param newPassword   New user password
- * @param confirmationPassword   Confirmation of the new user password
+ * @param oldPassword          The user's existing password
+ * @param newPassword          New user password
+ * @param confirmationPassword Confirmation of the new user password
  */
-@Immutable
+
 public record ChangeUserPasswordDTO(String oldPassword, String newPassword, String confirmationPassword) {
 }

--- a/src/main/java/pl/simpleascoding/tutoringplatform/dto/CreateUserDTO.java
+++ b/src/main/java/pl/simpleascoding/tutoringplatform/dto/CreateUserDTO.java
@@ -1,7 +1,4 @@
 package pl.simpleascoding.tutoringplatform.dto;
 
-import org.hibernate.annotations.Immutable;
-
-@Immutable
 public record CreateUserDTO(String username, String password, String name, String surname, String email) {
 }

--- a/src/main/java/pl/simpleascoding/tutoringplatform/dto/CredentialsDTO.java
+++ b/src/main/java/pl/simpleascoding/tutoringplatform/dto/CredentialsDTO.java
@@ -1,7 +1,4 @@
 package pl.simpleascoding.tutoringplatform.dto;
 
-import org.hibernate.annotations.Immutable;
-
-@Immutable
 public record CredentialsDTO(String username, String password) {
 }

--- a/src/main/java/pl/simpleascoding/tutoringplatform/dto/ModifyUserDTO.java
+++ b/src/main/java/pl/simpleascoding/tutoringplatform/dto/ModifyUserDTO.java
@@ -1,7 +1,4 @@
 package pl.simpleascoding.tutoringplatform.dto;
 
-import org.hibernate.annotations.Immutable;
-
-@Immutable
 public record ModifyUserDTO(String name, String surname) {
 }

--- a/src/main/java/pl/simpleascoding/tutoringplatform/dto/ReviewDTO.java
+++ b/src/main/java/pl/simpleascoding/tutoringplatform/dto/ReviewDTO.java
@@ -1,9 +1,6 @@
 package pl.simpleascoding.tutoringplatform.dto;
 
-import org.hibernate.annotations.Immutable;
-
 import java.time.Instant;
 
-@Immutable
 public record ReviewDTO(long id, String content, byte stars, UserDTO author, UserDTO receiver, Instant createdAt) {
 }

--- a/src/main/java/pl/simpleascoding/tutoringplatform/dto/RscpDTO.java
+++ b/src/main/java/pl/simpleascoding/tutoringplatform/dto/RscpDTO.java
@@ -1,6 +1,5 @@
 package pl.simpleascoding.tutoringplatform.dto;
 
-import org.hibernate.annotations.Immutable;
 import org.springframework.lang.Nullable;
 import pl.simpleascoding.tutoringplatform.rscp.RscpStatus;
 
@@ -13,6 +12,5 @@ import pl.simpleascoding.tutoringplatform.rscp.RscpStatus;
  * @param message the status message
  * @param body    the response body
  */
-@Immutable
 public record RscpDTO<T>(RscpStatus status, @Nullable String message, @Nullable T body) {
 }

--- a/src/main/java/pl/simpleascoding/tutoringplatform/dto/SignAsTeacherDTO.java
+++ b/src/main/java/pl/simpleascoding/tutoringplatform/dto/SignAsTeacherDTO.java
@@ -1,7 +1,4 @@
 package pl.simpleascoding.tutoringplatform.dto;
 
-import org.hibernate.annotations.Immutable;
-
-@Immutable
 public record SignAsTeacherDTO(String username) {
 }

--- a/src/main/java/pl/simpleascoding/tutoringplatform/dto/UpdateReviewDTO.java
+++ b/src/main/java/pl/simpleascoding/tutoringplatform/dto/UpdateReviewDTO.java
@@ -1,10 +1,8 @@
 package pl.simpleascoding.tutoringplatform.dto;
 
-import org.hibernate.annotations.Immutable;
 import org.hibernate.validator.constraints.Range;
 
 import javax.validation.constraints.Size;
 
-@Immutable
 public record UpdateReviewDTO(@Size(max = 400) String content, @Range(min = 1, max = 5) byte stars) {
 }

--- a/src/main/java/pl/simpleascoding/tutoringplatform/dto/UserDTO.java
+++ b/src/main/java/pl/simpleascoding/tutoringplatform/dto/UserDTO.java
@@ -1,10 +1,8 @@
 package pl.simpleascoding.tutoringplatform.dto;
 
-import org.hibernate.annotations.Immutable;
 import pl.simpleascoding.tutoringplatform.domain.user.RoleType;
 
 import java.util.Set;
 
-@Immutable
 public record UserDTO(Long id, String username, String name, String surname, String email, Set<RoleType> roles) {
 }


### PR DESCRIPTION
Java records are immutable by default. Annotation org.hibernate.annotations.Immutable should be used for entity class.