### PR TITLE
Fix/deleted  "-T 1C" from readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Run with root rights
 sudo ./scripts/database-launch-starter/database-launch-starter.bash
 ```
 
-### 2. Launching The Project
+### Launching The Project
 After creating the database we install the project from the tutorial-platform directory.
 Important! The project will not build without a database connection.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Important! The project will not build without a database connection.
 
 #### 2.1. Building an Application
 ```shell
-mvn clean install -T 1C
+mvn clean install
 ```
 
 #### 2.2. Running application


### PR DESCRIPTION
in Readme.md in information about building is command: mvn clean install -T 1C but -T 1C is useless in this moment, so i deleted it.

+corrected anchor in markdown for Launching The Project