### PR TITLE
 Refactor test methods in UserServiceImplTest class to adhere to the given-when-then convention using BDDMockito syntax #151 

### DIFF
--- a/src/test/java/pl/simpleascoding/tutoringplatform/user/UserServiceImplTest.java
+++ b/src/test/java/pl/simpleascoding/tutoringplatform/user/UserServiceImplTest.java
@@ -89,7 +89,7 @@ class UserServiceImplTest {
         UserNotFoundException exception
                 = assertThrows(UserNotFoundException.class, () -> userServiceImpl.getUserByUsername(USERNAME));
 
-        assertThat(exception.getMessage(), is(equalTo("User with username " + USERNAME + " not found")));
+        assertThat(exception.getMessage(), is(equalTo("User "+ USERNAME + " not found")));
     }
 
     private User createUserEntity() {

--- a/src/test/java/pl/simpleascoding/tutoringplatform/user/UserServiceImplTest.java
+++ b/src/test/java/pl/simpleascoding/tutoringplatform/user/UserServiceImplTest.java
@@ -14,7 +14,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
+
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceImplTest {
@@ -42,7 +43,7 @@ class UserServiceImplTest {
     void whenGetUserById_thenCorrectUserShouldBeReturned() {
         //given
         User user = createUserEntity();
-        when(userRepository.findById(ID_1L)).thenReturn(Optional.of(user));
+        given(userRepository.findById(ID_1L)).willReturn(Optional.of(user));
 
         //when
         User result = userServiceImpl.getUserById(ID_1L);
@@ -55,13 +56,13 @@ class UserServiceImplTest {
     @Test
     void whenGetUserById_thenUserNotFoundExceptionShouldBeThrown() {
         //given
-        when(userRepository.findById(ID_1L)).thenReturn(Optional.empty());
+        given(userRepository.findById(ID_1L)).willReturn(Optional.empty());
 
         //when & then
-        UserNotFoundException exception =
-                assertThrows(UserNotFoundException.class, () -> userServiceImpl.getUserById(ID_1L));
+        UserNotFoundException exception
+                = assertThrows(UserNotFoundException.class, () -> userServiceImpl.getUserById(ID_1L));
 
-        assertThat(exception.getMessage(), is(equalTo("User with id 1 not found")));
+        assertThat(exception.getMessage(), is(equalTo("User with id " + ID_1L + " not found")));
     }
 
     @DisplayName("Should return user with given username")
@@ -69,10 +70,10 @@ class UserServiceImplTest {
     void whenGetUserByUsername_thenCorrectUserShouldBeReturned() {
         //given
         User user = createUserEntity();
-        when(userRepository.findUserByUsername("TestUser")).thenReturn(Optional.of(user));
+        given(userRepository.findUserByUsername(USERNAME)).willReturn(Optional.of(user));
 
         //when
-        User result = userServiceImpl.getUserByUsername("TestUser");
+        User result = userServiceImpl.getUserByUsername(USERNAME);
 
         //then
         assertThat(result, is(equalTo(user)));
@@ -82,10 +83,13 @@ class UserServiceImplTest {
     @Test
     void whenGetUserByUsername_thenUserNotFoundExceptionShouldBeThrown() {
         //given
-        when(userRepository.findUserByUsername(USERNAME)).thenReturn(Optional.empty());
+        given(userRepository.findUserByUsername(USERNAME)).willReturn(Optional.empty());
 
         //when & then
-        assertThrows(UserNotFoundException.class, () -> userServiceImpl.getUserByUsername(USERNAME));
+        UserNotFoundException exception
+                = assertThrows(UserNotFoundException.class, () -> userServiceImpl.getUserByUsername(USERNAME));
+
+        assertThat(exception.getMessage(), is(equalTo("User with username " + USERNAME + " not found")));
     }
 
     private User createUserEntity() {


### PR DESCRIPTION
The following methods have been modified to improve their structure and align with the given-when-then convention using BDDMockito syntax:

- whenGetUserById_thenCorrectUserShouldBeReturned
- whenGetUserById_thenUserNotFoundExceptionShouldBeThrown
- whenGetUserByUsername_thenCorrectUserShouldBeReturned
- whenGetUserByUsername_thenUserNotFoundExceptionShouldBeThrown